### PR TITLE
Add permission step for gradlew before running tests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,28 +1,23 @@
 name: CI for Gradle Project
 
-
 on:
   pull_request:
     branches:
       - main
 
-
 jobs:
   test:
     runs-on: ubuntu-latest
 
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
 
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
-
 
       - name: Cache Gradle dependencies
         uses: actions/cache@v3
@@ -34,6 +29,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle
 
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
 
       - name: Run tests
         run: ./gradlew test


### PR DESCRIPTION
Title: Add permission step for gradlew before running tests

Description: This pull request adds a step to grant execute permission to the gradlew script before running the tests in the GitHub Actions workflow. This change is necessary to ensure that the gradlew script has the proper permissions on the CI environment, allowing it to execute properly when running the ./gradlew test command.

Changes made:

Added a step to run chmod +x ./gradlew before executing the tests.
This update ensures that the Gradle wrapper can be executed successfully during continuous integration runs on GitHub Actions.